### PR TITLE
Restore usage info (FREEPBX-12690)

### DIFF
--- a/assets/js/paging.js
+++ b/assets/js/paging.js
@@ -73,12 +73,12 @@ $(document).ready(function(){
 });
 
 function linkFormatter(value){
-	html = '<a href="?display=paging&view=form&extdisplay='+encodeURIComponent(value)+'"><i class="fa fa-pencil"></i></a>&nbsp;';
+	html = '<a href="?display=paging&view=form&extdisplay='+encodeURIComponent(value)+'"><i class="fa fa-edit"></i></a>&nbsp;';
 	html += '<a href="?display=paging&action=delete&extdisplay='+encodeURIComponent(value)+'" class="delAction"><i class="fa fa-trash"></i></a>&nbsp;';
 	return html;
 }
 function bnLinkFormatter(value){
-	html = '<a href="?display=paging&view=form&extdisplay='+value+'"><i class="fa fa-pencil"></i>&nbsp;'+value+'</a>';
+	html = '<a href="?display=paging&view=form&extdisplay='+value+'"><i class="fa fa-edit"></i>&nbsp;'+value+'</a>';
 	return html;
 }
 function defaultCheck(val){

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -779,7 +779,7 @@ function paging_getdestinfo($dest) {
 }
 
 function paging_getdest($exten) {
-	return array('pagegroups,'.$exten.',1');
+	return array('app-pagegroups,'.$exten.',1');
 }
 
 function paging_get_autoanswer_defaults($orderd = false) {

--- a/page.paging.php
+++ b/page.paging.php
@@ -8,8 +8,10 @@ switch ($_GET['view']) {
 	case 'form':
 		if (isset($request['extdisplay'])) {
 			$usage_list = framework_display_destination_usage(paging_getdest($request['extdisplay']));
+		} else {
+			$usage_list = '';
 		}
-		$content = load_view(__DIR__.'/views/formwrap.php', array('request' => $request, 'amp_conf'=> $amp_conf,));
+		$content = load_view(__DIR__.'/views/formwrap.php', array('request' => $request, 'amp_conf'=> $amp_conf, 'usage_list' => $usage_list,));
 	break;
 	default:
 		$content = load_view(__DIR__.'/views/overview.php', array('request' => $request));

--- a/page.paging.php
+++ b/page.paging.php
@@ -6,6 +6,9 @@ $request = $_REQUEST;
 $request['view'] = isset($request['view'])?$request['view']:'';
 switch ($_GET['view']) {
 	case 'form':
+		if (isset($request['extdisplay'])) {
+			$usage_list = framework_display_destination_usage(paging_getdest($request['extdisplay']));
+		}
 		$content = load_view(__DIR__.'/views/formwrap.php', array('request' => $request, 'amp_conf'=> $amp_conf,));
 	break;
 	default:

--- a/views/formwrap.php
+++ b/views/formwrap.php
@@ -7,6 +7,17 @@ if (!defined('FREEPBX_IS_AUTH')) { die('No direct script access allowed'); }
 ?>
 <div class="container-fluid">
 	<h1><?php echo _("Page Group") ?></h1>
+<?php if (!empty($usage_list)):?>
+	<div class="panel panel-default fpbx-usageinfo">
+		<div class="panel-heading">
+			<?php echo $usage_list['text']?>
+		</div>
+		<div class="panel-body">
+			<?php echo $usage_list['tooltip']?>
+		</div>
+	</div>
+
+<?php endif?>
 	<div class = "display full-border">
 		<div class="row">
 			<div class="col-sm-12">


### PR DESCRIPTION
I had to update `paging_getdest()` to make this work properly, because it was returning a value that didn't match the dialplan. I notice this function is called in `view.functions.php` when handling popover submits, so I tested to confirm that functionality wasn't broken. Not sure if this has any real impact but thought I'd mention it.

Screenshot:
![screenshot 2017-04-28 14 46 09](https://cloud.githubusercontent.com/assets/1329102/25548682/890455c2-2c22-11e7-843c-78f2f3cbf2df.png)
